### PR TITLE
Add Unicode handling

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -61,6 +61,8 @@ permalink: /extension/%(name)s/
 ---
 ''' % extension
 
+    if type(extension.readme) == unicode:
+        extension.readme = extension.readme.encode('ascii', 'xmlcharrefreplace')
     out = '%s\n\n%s\n' % (frontmatter, extension.readme)
     outfo.write(out)
     outfo.close()


### PR DESCRIPTION
For READMEs in unicode, a UnicodeDecodeError was being raised when generating the extension Markdown file.