### PR TITLE
Update documentation for NHM extensions

### DIFF
--- a/extensions/ckanpackager.md
+++ b/extensions/ckanpackager.md
@@ -2,7 +2,7 @@
 layout: extension
 name: ckanpackager
 title: A stand-alone service to pack a given CKAN resource in a ZIP file and email the link to a user
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-ckanpackager
@@ -12,47 +12,128 @@ permalink: /extension/ckanpackager/
 ---
 
 
-ckanext-ckanpackager
-====================
+# ckanext-ckanpackager
 
-Overview
---------
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-ckanpackager/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-ckanpackager)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-ckanpackager/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-ckanpackager)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-CKAN extension to provide a user interface to download resources using [ckanpackager](http://github.com/NaturalHistoryMuseum/ckanpackager)
+_A CKAN extension that provides a user interface to download resources with [ckanpackager](http://github.com/NaturalHistoryMuseum/ckanpackager)._
+
+
+# Overview
+
+**This extension will not work without [ckanpackager](http://github.com/NaturalHistoryMuseum/ckanpackager).**
 
 Ckanpackager is a stand-alone service that can be instructed to fetch data on a [CKAN](http://ckan.org) site using the datastore API, pack the data in a ZIP file and email the link to a given address. See the [ckanpackager github page](http://github.com/NaturalHistoryMuseum/ckanpackager) for more information.
 
-Note that to embed the user interface you must provide your own template (typically overriding CKAN's). See the CKAN documentation.
-
 The extension provides an HTML snippet that can be used to replace the Download button on resources. The new button will:
+- Provide an overlay explaining the link will be sent later on;
+- If anonymous downloading is enabled, provide a form for users to enter the destination email address;
+- On resource pages, the button will ensure that currently applied filters and searches are forwarded on to the ckanpackager service.
 
--   Provide an overlay explaining the link will be sent later on;
--   If anonymous downloading is enabled, provide a form for users to enter the destination email address;
--   On resource pages, the button will ensure that currently applied filters and searches are forwarded on to the ckanpackager service.
+This extension uses a database table in the CKAN database to store stats about packaging events.
 
-Usage
------
 
-Enable the plugin by adding it to `ckan.plugins` in your configuration file.
+# Installation
 
-To embed the button on a page, add the following to a Jinja2 template:
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
 
-        {%raw%}{% {%endraw%}snippet 'ckanpackager/snippets/package_resource.html',
-           res=res, pkg=pkg, bt_class="icon-download", bt_text=_('Download')
-       {%raw%} %}{%endraw%}
+1. Clone the repository into the `src` folder:
 
-Where `res` is a resource object and `pkg` a package object. You can use the above snippet as it to replace the download button in `package/resource_read.html`
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager.git
+  ```
 
-Compatibility
--------------
+2. Activate the virtual env:
 
-The current version is being developed to work against CKAN's 1251 branch (resource views).
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
 
-Configuration
--------------
+3. Install the requirements from requirements.txt:
 
--   `ckanpackager.url`: The URL of the ckan packager service, eg. `http://ckanpackager.example.com:8765/package`
--   `ckanpackager.secret`: The shared secret
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-ckanpackager
+  pip install -r requirements.txt
+  ```
 
-TODO: Add a configuration item to enable/disable anonymous downloading.
+4. Run setup.py:
 
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-ckanpackager
+  python setup.py develop
+  ```
+
+5. Add 'ckanpackager' to the list of plugins in your `$CONFIG_FILE`:
+
+  ```ini
+  ckan.plugins = ... ckanpackager
+  ```
+
+
+# Configuration
+
+There are two options that _must_ be specified in your .ini config file.
+
+## **[REQUIRED]**
+
+Name|Description|Options
+--|--|--
+`ckanpackager.url`|URL to the ckanpackager endpoint|
+`ckanpackager.secret`|Shared secret with the ckanpackager instance|
+
+
+# Further Steps
+
+1. Initialise the database table:
+
+  ```bash
+  paster --plugin=ckanext-ckanpackager initdb -c $CONFIG_FILE
+  ```
+
+# Usage
+
+## Actions
+
+### `packager_stats`
+Provides statistical information about the download requests made to the packager. All of the items in the `data_dict` are optional.
+
+```python
+from ckan.plugins import toolkit
+
+data_dict = {
+                'resource_id': RESOURCE_ID,
+                'offset': 0,
+                'limit': 100,
+                'email': REQUESTER_EMAIL
+            }
+
+toolkit.get_action('packager_stats')(
+    context,
+    data_dict
+)
+```
+
+## Commands
+
+### `initdb`
+Initialises the ckanpackager database table.
+
+1.
+    ```bash
+    paster --plugin=ckanext-ckanpackager initdb -c $CONFIG_FILE
+    ```
+
+## Templates
+
+Add the following snippet to templates where you want the button to appear:
+
+```html+jinja
+{% snippet 'ckanpackager/snippets/package_resource.html',
+   res=res, pkg=pkg, bt_class="fas fa-download", bt_text=_('Download')
+%}
+```

--- a/extensions/contact.md
+++ b/extensions/contact.md
@@ -2,7 +2,7 @@
 layout: extension
 name: contact
 title: Adds a contact form
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-contact
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-contact

--- a/extensions/contact.md
+++ b/extensions/contact.md
@@ -12,22 +12,101 @@ permalink: /extension/contact/
 ---
 
 
-CKAN Contact Extension
-======================
+# ckanext-contact
 
-This extension adds a contact form
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-contact/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-contact)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-contact/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-contact)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-**DEMO:** <http://data.nhm.ac.uk/>
+_A CKAN extension for adding popup contact forms to pages._
 
-**Settings**
 
-     ckanext.contact.mail_to =
-     ckanext.contact.recipient_name =
-     ckanext.contact.subject =
+# Overview
 
-If ckanext.contact.mail\_to is not set, the form will fall back to using the CKAN setting "email\_to".
+Borrows much of the contact form code from [ckanext-surrey](https://github.com/CityofSurrey/ckanext-surrey).
 
-**Credits:**
+An example can be seen on the Natural History Museum's [Data Portal](https://data.nhm.ac.uk) when clicking "_Contact dataset curator._"
 
-Borrows much of the contact form code from <https://github.com/CityofSurrey/ckanext-surrey>
+This extension now includes Google's [reCAPTCHA](https://www.google.com/recaptcha) for preventing spam submissions.
 
+
+# Installation
+
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
+
+1. Clone the repository into the `src` folder:
+
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-contact.git
+  ```
+
+2. Activate the virtual env:
+
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
+
+3. Install the requirements from requirements.txt:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-contact
+  pip install -r requirements.txt
+  ```
+
+4. Run setup.py:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-contact
+  python setup.py develop
+  ```
+
+5. Add 'contact' to the list of plugins in your `$CONFIG_FILE`:
+
+  ```ini
+  ckan.plugins = ... contact
+  ```
+
+
+# Configuration
+
+There are no settings that _must_ be provided in your .ini config file, but there are some options:
+
+## Email
+
+Name|Description|Default
+--|--|--
+`ckanext.contact.mail_to`|Email address to submit to|`email_to`
+`ckanext.contact.recipient_name`|Name of the recipient|`ckan.site_title`
+`ckanext.contact.subject`|Email subject for the submitted form|'Contact/Question from visitor'
+
+## Recaptcha
+
+Name|Description|Default
+--|--|--
+`ckanext.contact.recaptcha_v3_key`|API key for the reCAPTCHA service.|False (i.e. disabled)
+`ckanext.contact.recaptcha_v3_secret`|API secret for the reCAPTCHA service.|False (i.e. disabled)
+`ckanext.contact.recaptcha_v3_action`|`data-module-action` for the form/button|  
+
+
+# Further Setup
+
+To use reCAPTCHA, you must register a site with the Google [reCAPTCHA](https://www.google.com/recaptcha) service and add your API key and secret in the [configuration](#configuration).
+
+# Usage
+
+Add the following HTML where you want the contact button to appear:
+
+```html+jinja
+{% set params = {...} %}
+
+<a class="btn btn-primary" data-module="modal-contact" data-module-template="{{ h.get_contact_form_template_url(params) }}" href="{{ h.url_for('contact.form', **params) }}" title="{{ _('Contact') }}">
+    <i class="fas fa-envelope"></i>{{ link_text if link_text else _('CONTACT BUTTON TEXT') }}
+</a>
+
+{% resource 'ckanext-contact/main' %}
+```
+
+Where `params` is a dict with three entries: package_id, resource_id, record_id (all of which are optional).

--- a/extensions/doi.md
+++ b/extensions/doi.md
@@ -2,7 +2,7 @@
 layout: extension
 name: doi
 title: CKAN extension for assigning a digital object identifier (DOI) to datasets
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-doi
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-doi
@@ -12,135 +12,163 @@ permalink: /extension/doi/
 ---
 
 
-ckanext-doi
-===========
+# ckanext-doi
 
-Overview
---------
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-doi/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-doi)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-doi/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-doi)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-CKAN extension for assigning a digital object identifier (DOI) to datasets, using the DataCite DOI service.
+_A CKAN extension for assigning a digital object identifier (DOI) to datasets, using the DataCite DOI service._
+
+
+# Overview
+
+This extension assigns a digital object identifier (DOI) to datasets, using the DataCite DOI service.
 
 When a new dataset is created it is assigned a new DOI. This DOI will be in the format:
 
-<http://dx.doi.org/%5Bprefix%5D/%5Brandom> 7 digit integer\]
+`https://doi.org/[prefix]/[random 7 digit integer]`
 
 If the new dataset is active and public, the DOI and metadata will be registered with DataCite.
 
-If the dataset is draft or private, the DOI will not be registered with DataCite. When the dataset is made active & public, the DOI will be submitted.
-This allows datasets to be embargoed, but still provides a DOi to be referenced in publications.
+If the dataset is draft or private, the DOI will not be registered with DataCite.  When the dataset is made active & public, the DOI will be submitted.
+This allows datasets to be embargoed, but still provides a DOI to be referenced in publications.     
 
 You will need an account with a DataCite DOI service provider to use this extension.
 
-Installation
-------------
+## DOI Metadata
+Uses DataCite Metadata Schema v 3.1 https://schema.datacite.org/meta/kernel-3.1/index.html
 
-This extension can be installed in the same way as any other - download it, activate it and enable the plugin. <http://docs.ckan.org/en/latest/extensions/tutorial.html#installing-the-extension>
+Dataset package fields and CKAN config settings are mapped to the DataCite Schema  
 
-However it will only work if you have signed up for an account with DataCite.
+|CKAN Dataset Field                 |DataCite Schema
+|--- | ---
+|dataset:title                      |title
+|dataset:creator                    |author
+|config:ckanext.doi.publisher       |publisher
+|dataset:notes                      |description
+|resource formats                   |format
+|dataset:tags                       |subject
+|dataset:licence (title)            |rights
+|dataset:version                    |version
+|dataset:extras spacial             |geo_box
 
-You will need a development / test account to use this plugin in test mode. And to mint active DOIs you will need a live DataCite account.
-
-DOI Metadata
-------------
-
-Uses DataCite Metadata Schema v 3.1 <https://schema.datacite.org/meta/kernel-3.1/index.html>
-
-Dataset package fields and CKAN config settings are mapped to the DataCite Schema
-
-| CKAN Dataset Field           | DataCite Schema |
-|------------------------------|-----------------|
-| dataset:title                | title           |
-| dataset:creator              | author          |
-| config:ckanext.doi.publisher | publisher       |
-| dataset:notes                | description     |
-| resource formats             | format          |
-| dataset:tags                 | subject         |
-| dataset:licence (title)      | rights          |
-| dataset:version              | version         |
-| dataset:extras spacial       | geo\_box        |
 
 DataCite title and author are mandatory metadata fields, so dataset title and creator fields are made required fields.
-This has been implemented in the theme layer, with another check in IPackageController.after\_update, which raises
-a DOIMetadataException if the title or author fields do not exist.
+This has been implemented in the theme layer, with another check in IPackageController.after_update, which raises a DOIMetadataException if the title or author fields do not exist.
 
 It is recommended plugins implementing DOIs add additional validation checks to their schema.
 
-This plugin implements a build\_metadata interface, so the metadata can be customised.
 
-See [Natural History Museum extension](https://github.com/NaturalHistoryMuseum/ckanext-nhm) for an implementation of this interface.
+# Installation
 
-Configuration
--------------
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
 
-``` python
-ckanext.doi.account_name =
-ckanext.doi.account_password =
-ckanext.doi.prefix = 
-ckanext.doi.publisher = 
+1. Clone the repository into the `src` folder:
+
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-doi.git
+  ```
+
+2. Activate the virtual env:
+
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
+
+3. Install the requirements from requirements.txt:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-doi
+  pip install -r requirements.txt
+  ```
+
+4. Run setup.py:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-doi
+  python setup.py develop
+  ```
+
+5. Add 'doi' to the list of plugins in your `$CONFIG_FILE`:
+
+  ```ini
+  ckan.plugins = ... doi
+  ```
+
+
+# Configuration
+
+There are a number of options that can be specified in your .ini config file.
+
+## DateCite Credentials **[REQUIRED]**
+
+These will be given to you by your DataCite provider.
+
+```ini
+ckanext.doi.account_name = DATACITE-ACCOUNT-NAME
+ckanext.doi.account_password = DATACITE-ACCOUNT-PASSWORD
+ckanext.doi.prefix = DATACITE-PREFIX
+```
+
+## Institution Name **[REQUIRED]**
+
+You also need to provide the name of the institution publishing the DOIs (e.g. Natural History Museum).
+
+```ini
+ckanext.doi.publisher = PUBLISHING-INSTITUTION
+```
+
+## Test/Deug Mode **[REQUIRED]**
+
+If test mode is set to true, the DOIs will use the DataCite test prefix 10.5072.
+
+```ini
 ckanext.doi.test_mode = True or False
-ckanext.doi.site_url =  # Defaults to ckan.site_url if not set 
-ckanext.doi.site_title = # Optional - site title to use in the citation - eg Natural History Museum Data Portal (data.nhm.ac.uk)
 ```
 
-Account name, password and prefix will be provided by your DataCite provider.
+## Other options
 
-Publisher is the name of the publishing institution - eg: Natural History Museum.
+Name|Description|Default
+--|---|--
+`ckanext.doi.site_url`|Used to build the link back to the dataset|`ckan.site_url`
+`ckanext.doi.site_title`|Site title to use in the citation|
 
-The site URL is used to build the link back to the dataset:
 
-<http://%5Bsite_url%5D/datatset/package_id>
+# Further Setup
 
-If site\_url is not set, ckan.site\_url will be used instead.
+This extension will only work if you have signed up for an account with [DataCite](https://datacite.org).  
 
-If test mode is set to true, the DOIs will use the DataCite test prefix 10.5072
+You will need a development/test account to use this plugin in test mode, and a live account to mint active DOIs.
 
-To delete all test prefixes, use the command:
 
-``` python
-paster doi delete-tests -c /etc/ckan/default/development.ini
+# Usage
+
+## Commands
+
+### `doi`
+
+1. `delete-tests`: delete all test DOIs.
+    ```bash
+    paster --plugin=ckanext-doi doi delete-tests -c $CONFIG_FILE
+    ```
+
+## Interfaces
+
+This plugin implements a build_metadata interface, so the metadata can be customised.
+See [ckanext-nhm](https://github.com/NaturalHistoryMuseum/ckanext-nhm) for an implementation of this interface.
+
+## Templates
+
+### Package citation snippet
+```html+jinja
+{% snippet "doi/snippets/package_citation.html", pkg_dict=g.pkg_dict %}
 ```
 
-Releases
---------
-
-### 0.1
-
-Initial release
-
-### 0.2
-
-A DOI will be created regardless od Dataset status.
-Only when a dataset is active and public will the DOI and MetaData be published to DataCite.
-
-Removed locking of DOI metadata fields after 10 days. This is an interim solution before implementing DOI versioning.
-
-Added build\_metadata interface (and moved custom NHM metadata fields to ckanext-nhm).
-
-Added schema migration command.r
-
-Upgrade notes
--------------
-
-### 0.2
-
-Requires a schema change 001 & 002 - adds DOI published date and removes DOI created columns. See ckanext.doi.migration
-
-Run with:
-
-``` python
-paster doi upgrade-db -c /etc/ckan/default/development.ini
+### Resource citation snippet
+```html+jinja
+{% snippet "doi/snippets/resource_citation.html", pkg_dict=g.pkg_dict, res=res %}
 ```
-
-Roadmap
--------
-
-Features planned for development.
-
-1.  DOI versioning - allow option to create a new DOI on update (or if core metadata fields are updated). This new DOI will be linked to the master/original DOI.
-
-2.  Embargoed for set length of time. User can select date on which the dataset is to be made public, and the DOI submitted to DataCite.
-
-3.  Tests. There are no tests.
-
-
-

--- a/extensions/gallery.md
+++ b/extensions/gallery.md
@@ -2,7 +2,7 @@
 layout: extension
 name: gallery
 title: CKAN extension for a dataset gallery view
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-gallery
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-gallery
@@ -12,12 +12,112 @@ permalink: /extension/gallery/
 ---
 
 
-ckanext-gallery
-===============
+# ckanext-gallery
 
-CKAN extension for a dataset gallery view.
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-gallery/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-gallery)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-gallery/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-gallery)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-Based on <https://blueimp.github.io/Gallery/>
+_A CKAN extension for a dataset gallery view._
 
-You can see an example at: <http://data.nhm.ac.uk/dataset/collection-specimens/resource/05ff2255-c38a-40c9-b657-4ccb55ab2feb?view_id=6ba121d1-da26-4ee1-81fa-7da11e68f68e>
 
+# Overview
+
+Adds a gallery view for resources on a CKAN instance. Two plugins are included in this extension: `gallery` and `gallery_image`.
+
+Based on [blueimp Gallery](https://blueimp.github.io/Gallery).
+
+
+# Installation
+
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
+
+1. Clone the repository into the `src` folder:
+
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-gallery.git
+  ```
+
+2. Activate the virtual env:
+
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
+
+3. Install the requirements from requirements.txt:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-gallery
+  pip install -r requirements.txt
+  ```
+
+4. Run setup.py:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-gallery
+  python setup.py develop
+  ```
+
+5. Add 'gallery' to the list of plugins in your `$CONFIG_FILE`:
+
+  ```ini
+  ckan.plugins = ... gallery
+  ```
+
+# Configuration
+
+There's only one option that can be specified in the `.ini` file:
+
+Name|Description|Default
+--|---|--
+`ckanext.gallery.records_per_page`|Number of images to display on a page|32
+
+
+# Usage
+
+To use as a view, the 'Gallery' type should be available after installing the plugin.
+
+## Interfaces
+
+The `IGalleryImage` interface allows plugins to override settings.
+
+```python
+from ckan.plugins import SingletonPlugin, implements
+from ckanext.gallery.plugins.interfaces import IGalleryImage
+
+class YourPlugin(SingletonPlugin):
+  implements(IGalleryImage)
+
+
+  def image_info(self):
+    '''
+    Return info for this plugin. If resource type is set,
+    only datasets of that type will be available.
+    '''
+    return {u'title': u'Text',
+            u'resource_type': [u'csv', u'tsv'],
+            u'field_type': [u'text']}
+
+
+  def get_images(self, field_value, record, data_dict):
+    '''
+    Process images from a single record to return custom metadata.
+    The field_value depends on the image field you choose.
+    '''
+    images = [{
+      u'href': field_value[u'url'],
+      u'thumbnail': field_value[u'url'].replace(u'preview', u'thumbnail'),
+      u'record_id': record[u'_id']
+    } for img in field_value]
+    return image
+```
+
+## Templates
+
+### Gallery block snippet
+```html+jinja
+{% snippet 'gallery/snippets/gallery.html', images=g.images, resource_id=res.id %}
+```

--- a/extensions/graph.md
+++ b/extensions/graph.md
@@ -2,7 +2,7 @@
 layout: extension
 name: graph
 title: CKAN extension for graph views, with data processing moved to the backend
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-graph
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-graph

--- a/extensions/graph.md
+++ b/extensions/graph.md
@@ -12,19 +12,106 @@ permalink: /extension/graph/
 ---
 
 
-ckanext-graph
-=============
+# ckanext-graph
 
-CKAN extension for graph views, with data processing moved to the backend.
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-graph/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-graph)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-graph/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-graph)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-At the moment it just has one type of graph - temporal. Select a date created field, and a graph will show how the dataset has increaed over time.
+_A CKAN extension that adds a graph view for resources._
 
-More graphs are planner for the future.
 
-Configuration
--------------
+# Overview
 
-ckanext.gallery.field\_separator
+Adds graph views for resources on a CKAN instance. Two types of graph are available: temporal (a line graph showing count over time based on a specified date field), and categorical (a bar chart showing counts for various values in a specified field).
 
-Defaults to ;
 
+**NB**: the current version of this extension only works with the Natural History Museum's [ElasticSearch datastore CKAN backend](https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore). _However_, it is designed to be extensible, so if you would like to use this extension with a different backend (e.g. the standard PostgreSQL datastore), please see the [Extending](#extending) section.
+
+
+# Installation
+
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
+
+1. Clone the repository into the `src` folder:
+
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-graph.git
+  ```
+
+2. Activate the virtual env:
+
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
+
+3. Install the requirements from requirements.txt:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-graph
+  pip install -r requirements.txt
+  ```
+
+4. Run setup.py:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-graph
+  python setup.py develop
+  ```
+
+5. Add 'graph' to the list of plugins in your `$CONFIG_FILE`:
+
+  ```ini
+  ckan.plugins = ... graph
+  ```
+
+# Configuration
+
+There is currently only one option that can be specified in your .ini config file.
+
+Name|Description|Options|Default
+--|--|--|--
+`ckanext.graph.backend`|The name of the backend to use (currently only `elasticsearch` is implemented)|elasticsearch, sql|elasticsearch
+
+
+# Usage
+
+## Templates
+
+The view will be added as an option with no further configuration necessary. However, if you wish to override or add content to the template, you can extend `templates/graph/view.html`:
+
+```html+jinja
+{% ckan_extends %}
+
+{% block my_new_block %}
+  <p>Look, some exciting new content.</p>
+{% endblock %}
+```
+
+
+# Extending
+
+To use this extension with a datastore backend other than the ElasticSearch backend already implemented, you'll have to subclass from `Query` in `ckanext-graph/ckanext/graph/db.py`.
+
+An unimplemented class for SQL queries is already in the file as an example:
+
+```python
+class SqlQuery(Query):
+    @property
+    def _date_query(self):
+        raise NotImplementedError()
+
+    @property
+    def _count_query(self):
+        raise NotImplementedError()
+
+    def run(self):
+        raise NotImplementedError()
+```
+
+If you add a new class, you'll have to add it to the dictionary in `Query.new()` method to make it available as a configurable option.
+
+If you do this, please submit a pull request! Contributions are always welcome.

--- a/extensions/ldap.md
+++ b/extensions/ldap.md
@@ -2,7 +2,7 @@
 layout: extension
 name: ldap
 title: CKAN plugin to provide LDAP authentication
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-ldap
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-ldap
@@ -12,68 +12,127 @@ permalink: /extension/ldap/
 ---
 
 
-ckanext-ldap
-============
+# ckanext-ldap
 
-Overview
---------
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-ldap/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-ldap)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-ldap/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-ldap)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-This plugin provides LDAP authentication for CKAN. Features include:
+_A CKAN extension that provides LDAP authentication._
 
--   Imports username, full name, email and description;
--   Can match against several LDAP fields (eg. username or full name);
--   Allows to have LDAP only authentication, or combine LDAP and basic CKAN authentication;
--   Can add LDAP users to a given organization automatically;
--   Works with Active Directory.
 
-Requirements
-------------
+# Overview
 
-This plugin uses the pythton-ldap module. This available to install via pip:
+This plugin provides LDAP authentication for CKAN.
 
-``` sh
-  pip install python-ldap
+Features include:
+- Imports username, full name, email and description;
+- Can match against several LDAP fields (eg. username or full name);
+- Allows to have LDAP only authentication, or combine LDAP and basic CKAN authentication;
+- Can add LDAP users to a given organization automatically;
+- Works with Active Directory.
+
+
+# Installation
+
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
+
+1. Clone the repository into the `src` folder:
+
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-ldap.git
+  ```
+
+2. Activate the virtual env:
+
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
+
+3. Install the requirements for `python-ldap`, e.g.:
+
+  ```bash
+  apt-get install libldap2-dev libsasl2-dev libssl-dev
+  ```
+
+4. Install the requirements from requirements.txt:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-ldap
+  pip install -r requirements.txt
+  ```
+
+5. Run setup.py:
+
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-ldap
+  python setup.py develop
+  ```
+
+6. Add 'ldap' to the list of plugins in your `$CONFIG_FILE`:
+
+  ```ini
+  ckan.plugins = ... ldap
+  ```
+
+# Configuration
+
+These are the options that can be specified in your .ini config file.
+
+## LDAP configuration **[REQUIRED]**
+
+Name|Description|Options
+--|--|--
+`ckanext.ldap.uri`|The URI of the LDAP server, of the form _ldap://example.com_. You can use the URI to specify TLS (use 'ldaps' protocol), and the port number (suffix ':port').|True/False
+`ckanext.ldap.base_dn`|The base dn in which to perform the search. Example: 'ou=USERS,dc=example,dc=com'.|  
+`ckanext.ldap.search.filter`|This is the search string that is sent to the LDAP server, in which '{login}' is replaced by the user name provided by the user. Example: 'sAMAccountName={login}'. The search performed here **must** return exactly 0 or 1 entry.|  
+`ckanext.ldap.username`|The LDAP attribute that will be used as the CKAN username. This **must** be unique.|  
+`ckanext.ldap.email`|The LDAP attribute to map to the user's email address. This **must** be unique.|  
+
+## Other options
+
+Name|Description|Options|Default
+--|--|--|--
+`ckanext.ldap.ckan_fallback`|If true this will attempt to log in against the CKAN user database when no LDAP user exists.|True, False|False
+`ckanext.ldap.prevent_edits`|If true, this will prevent LDAP users from editing their profile. Note that there is no problem in allowing users to change their details - even their user name can be changed. But you may prefer to keep things centralized in your LDAP server. **Important**: while this prevents the operation from happening, it won't actually remove the 'edit settings' button from the dashboard. You need to do this in your own template.|True/False|False
+`ckanext.ldap.auth.dn`|DN to use if LDAP server requires authentication.||
+`ckanext.ldap.auth.password`|Password to use if LDAP server requires authentication.||
+`ckanext.ldap.auth.method`|Authentication method|SIMPLE, SASL|
+`ckanext.ldap.auth.mechanism`|SASL mechanism to use, if auth.method is set to SASL.||
+`ckanext.ldap.fullname`|The LDAP attribute to map to the user's full name.||
+`ckanext.ldap.about`|The LDAP attribute to map to the user's description.||
+`ckanext.ldap.organization.id`|If this is set, users that log in using LDAP will automatically get added to the given organization. **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the organization of users who have already logged on.||
+`ckanext.ldap.organization.role`|The role given to users added in the given organization ('admin', 'editor' or 'member'). **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the role of users who have already logged on. This is only used if `ckanext.ldap.organization.id` is set. There is currently no functionality for mapping LDAP groups to CKAN roles, so this just assigns the same role to _every_ new LDAP user.|member, editor, admin|'member'
+`ckanext.ldap.search.alt`|An alternative search string for the LDAP filter. If this is present and the search using `ckanext.ldap.search.filter` returns exactly 0 results, then a search using this filter will be performed. If this search returns exactly one result, then it will be accepted. You can use this for example in Active Directory to match against both username and fullname by setting `ckanext.ldap.search.filter` to  'sAMAccountName={login}' and `ckanext.ldap.search.alt` to 'name={login}'. The approach of using two separate filter strings (rather than one with an or statement) ensures that priority will always be given to the unique id match. `ckanext.ldap.search.alt` however can  be used to match against more than one field. For example you could match against either the full name or the email address by setting `ckanext.ldap.search.alt` to '(\|(name={login})(mail={login}))'.||
+`ckanext.ldap.search.alt_msg`|A message that is output to the user when the search on `ckanext.ldap.search.filter` returns 0 results, and the search on `ckanext.ldap.search.alt` returns more than one result. Example: 'Please use your short account name instead'.||
+`ckanext.ldap.migrate`| If true this will change an existing CKAN user with the same username to an LDAP user. Otherwise, an exception `UserConflictError`is raised if LDAP-login with an already existing local CKAN username is attempted. This option provides a migration path from local CKAN authentication to LDAP authentication: Rename all users to their LDAP usernames and instruct them to login with their LDAP credentials. Migration then happens transparently.|True, False|False
+`ckanext.ldap.debug_level`|[python-ldap debug level](https://www.python-ldap.org/en/python-ldap-3.0.0b1/reference/ldap.html?highlight=debug_level#ldap.OPT_DEBUG_LEVEL).||0
+`ckanext.ldap.trace_level`|[python-ldap trace level](https://www.python-ldap.org/en/python-ldap-3.0.0b1/reference/ldap.html?highlight=trace_level#ldap.initialize).||0
+
+
+# Usage
+
+## Commands
+
+### `ldap`
+
+1. `setup-org`: create the organisation specified in `ckanext.ldap.organization.id`.
+    ```bash
+    paster --plugin=ckanext-ldap ldap setup-org -c $CONFIG_FILE
+    ```
+
+## Templates
+
+This extension overrides `templates/user/login.html` and sets the form action to the LDAP login handler.
+
+To use it elsewhere:
+
+```html+jinja
+{% set ldap_action = h.get_login_action() %}
+{% snippet "user/snippets/login_form.html", action=ldap_action, error_summary=error_summary %}
 ```
 
-Unless you install this from a binary, then building this will require ldap2, sasl2 and ssl development packages to be installed on your system. Under Debian and derivatives these can be installed by doing:
-
-``` sh
-apt-get install libldap2-dev libsasl2-dev libssl-dev
-```
-
-Configuration
--------------
-
-Configuration of an LDAP client is always tricky. Unfortunately this really varies from system to system - we cannot provide general advice, you need to check with the LDAP server administrator.
-
-The plugin provides the following **required** configuration items:
-
--   `ckanext.ldap.uri`: The URI of the LDAP server, of the form \_<ldap://example.com_>. You can use the URI to specify TLS (use 'ldaps' protocol), and the port number (suffix ':port');
--   `ckanext.ldap.base_dn`: The base dn in which to perform the search. Example: 'ou=USERS,dc=example,dc=com';
--   `ckanext.ldap.search.filter`: This is the search string that is sent to the LDAP server, in which '{login}' is replaced by the user name provided by the user. Example: 'sAMAccountName={login}'. The search performed here **must** return exactly 0 or 1 entry. See `ckanext.ldap.search.alt` to provide search on alternate fields;
--   `ckanext.ldap.username`: The LDAP attribute that will be used as the CKAN username. This **must** be unique;
--   `ckanext.ldap.email`: The LDAP attribute to map to the user's email address. This **must** be unique.
-
-In addition the plugin provides the following optional configuration items:
-
--   `ckanext.ldap.ckan_fallback`: If defined and true this will attempt to log in against the CKAN user database when no LDAP user exists;
--   `ckanext.ldap.prevent_edits`: If defined and true, this will prevent LDAP users from editing their profile. Note that there is no problem in allowing users to change their details - even their user name can be changed. But you may prefer to keep things centralized in your LDAP server. **Important**: while this prevents the operation from happening, it won't actually remove the 'edit settings' button from the dashboard. You need to do this in your own template;
--   `ckanext.ldap.auth.dn`: If your LDAP server requires authentication (eg. Active Directory), this should be the DN to use;
--   `ckanext.ldap.auth.password`: If your LDAP server requires authentication, add the password here;
--   `ckanext.ldap.fullname`: The LDAP attribute to map to the user's full name;
--   `ckanext.ldap.about`: The LDAP attribute to map to the user's description;
--   `ckanext.ldap.organization.id`: If this is set, users that log in using LDAP will automatically get added to the given organization. **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the organization of users who have already logged on;
--   `ckanext.ldap.organization.role`: The role given to users added in the given organization ('admin', 'editor' or 'member'). **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the role of users who have already logged on;
--   `ckanext.ldap.search.alt`: An alternative search string for the LDAP filter. If this is present and the search using `ckanext.ldap.search.filter` returns exactly 0 results, then a search using this filter will be performed. If this search returns exactly one result, then it will be accepted. You can use this for example in Active Directory to match against both username and fullname by setting `ckanext.ldap.search.filter` to 'sAMAccountName={login}' and `ckanext.ldap.search.alt` to 'name={login}'
-    The approach of using two separate filter strings (rather than one with an or statement) ensures that priority will always be given to the unique id match. `ckanext.ldap.search.alt` however can be used to match against more than one field. For example you could match against either the full name or the email address by setting `ckanext.ldap.search.alt` to '(|(name={login})(mail={login}))'.
--   `ckanext.ldap.search.alt_msg`: A message that is output to the user when the search on `ckanext.ldap.search.filter` returns 0 results, and the search on `ckanext.ldap.search.alt` returns more than one result. Example: 'Please use your short account name instead'.
-
-**Note**: Configuration options wihtout the `ckanext.` prefix are deprecated and will be eventually removed. Please update your settings if you are using them.
-
-CLI Commands
-------------
-
-To create the organisation specified in `ckanext.ldap.organization.id` use the paste command:
-
-paster --plugin=ckanext-ldap ldap setup-org -c /etc/ckan/default/development.ini
-
+The helper function `h.is_ldap_user()` is also provided for templates.

--- a/extensions/userdatasets.md
+++ b/extensions/userdatasets.md
@@ -2,7 +2,7 @@
 layout: extension
 name: userdatasets
 title: CKAN plugin to allow users with 'member' role within an organization to create/edit/delete their own datasets
-author: U.K. Natural History Museum
+author: Natural History Museum, London
 homepage: https://github.com/NaturalHistoryMuseum/ckanext-userdatasets
 github_user: NaturalHistoryMuseum
 github_repo: ckanext-userdatasets
@@ -12,65 +12,89 @@ permalink: /extension/userdatasets/
 ---
 
 
-ckanext-userdatasets
-====================
+# ckanext-userdatasets
 
-Overview
---------
+[![Travis](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-userdatasets/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-userdatasets)
+[![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-userdatasets/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-userdatasets)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.0a-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 
-A CKAN extension to allow organization members to create datasets, and edit or delete the datasets they have created.
+_A CKAN extension that allows organisation members to create datasets, and edit or delete the datasets they have created._
 
-This extension changes the permissions of users with the 'Member' role in an organization allowing them to create
+
+# Overview
+
+This extension changes the permissions of users with the 'Member' role in an organisation, allowing them to create
 datasets, and to edit or delete the datasets they have created. Unlike users with the 'Editor' role, they cannot
 edit or delete datasets created by other users.
 
 Notes:
-
--   This applies to the existing 'Member' role rather than creating a new one as it is currently not possible to add
-    new roles from an extension;
--   The plugin works with custom dataset types, however it will not work with other plugins which override
-    package/resource update/create/delete authorization functions, and package\_create/update actions.
+- This applies to the existing 'Member' role rather than creating a new one as it is currently not possible to add
+  new roles from an extension;
+- The plugin works with custom dataset types, however it will not work with other plugins which override
+  package/resource update/create/delete authorization functions, and package_create/update actions.
 
 **Warning: This plugin modifies CKAN's permission system. The current implementation cannot be considered fully
-safe and should only be used AT YOUR OWN RISK in a trusted environment. Ensure you run the tests with your plugins
-enabled.**
+ safe and should only be used AT YOUR OWN RISK in a trusted environment. Ensure you run the tests with your plugins
+ enabled.**
 
-Compatibility
--------------
 
--   v0.1 for CKAN 2.2
+# Installation
 
-Configuration
--------------
+Path variables used below:
+- `$INSTALL_FOLDER` (i.e. where CKAN is installed), e.g. `/usr/lib/ckan/default`
+- `$CONFIG_FILE`, e.g. `/etc/ckan/default/development.ini`
 
-The following configuration directives are available:
+1. Clone the repository into the `src` folder:
 
--   `userdatasets.default_auth_module`: The name of the module that holds the default implementation of the auth
-    functions. Only change this if you know what you are doing! Defaults to
-    `ckan.logic.auth`
--   `userdatasets.default_action_module`: The name of the module that holds the default implementation of the action
-    functions. Only change this if you know what you are doing! Defaults to
-    `ckan.logic.actin`
+  ```bash
+  cd $INSTALL_FOLDER/src
+  git clone https://github.com/NaturalHistoryMuseum/ckanext-userdatasets.git
+  ```
 
-Usage
------
+2. Activate the virtual env:
 
-1.  Install the package *in your ckan virtual environment*:
+  ```bash
+  . $INSTALL_FOLDER/bin/activate
+  ```
 
-``` sh
-    pip install git+https://github.com/NaturalHistoryMuseum/ckanext-userdatasets#egg=ckanext-userdatasets
-```
+3. Install the requirements from requirements.txt:
 
-1.  Add `userdatasets` to `ckan.plugins` in your configuration file.
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-userdatasets
+  pip install -r requirements.txt
+  ```
 
-Testing
--------
+4. Run setup.py:
 
-The plugin contains both unit tests and functional tests. From the source directory, run:
+  ```bash
+  cd $INSTALL_FOLDER/src/ckanext-userdatasets
+  python setup.py develop
+  ```
 
-``` sh
-    nosetests --ckan --with-pylons=test.ini ckanext/userdatasets/tests
-```
+5. Add 'userdatasets' to the list of plugins in your `$CONFIG_FILE`:
 
-This assumes that ckan's test.ini is in ../ckan/test.ini. Adjust accordingly.
+  ```ini
+  ckan.plugins = ... userdatasets
+  ```
 
+# Configuration
+
+These are the options that can be specified in your .ini config file. It's not recommended to change these settings unless you know what you're doing!
+
+Name|Description|Options|Default
+--|--|--|--
+`ckanext.userdatasets.default_auth_module`|Module that holds the default implementation of the auth functions.||`ckan.logic.auth`
+`ckanext.userdatasets.default_action_module`|Module that holds the default implementation of the action functions.||`ckan.logic.action`
+
+
+# Usage
+
+## Actions
+
+No new actions are defined in this extension; three are overridden to modify validators and permissions.
+
+### `package_create`
+
+### `package_update`
+
+### `organization_list_for_user`


### PR DESCRIPTION
Updates the documentation (i.e. copies the README) for the following extensions:

- ldap
- ckanpackager
- contact
- doi
- gallery
- graph
- userdatasets